### PR TITLE
Verificamos validaciones en actividad y asistencia

### DIFF
--- a/src/main/java/com/hyrule/eventos/hyrule/EventosHyrule.java
+++ b/src/main/java/com/hyrule/eventos/hyrule/EventosHyrule.java
@@ -4,12 +4,11 @@
 package com.hyrule.eventos.hyrule;
 
 import com.hyrule.eventos.hyrule.dbconnection.DBConnection;
-import com.hyrule.eventos.hyrule.dao.ParticipanteDAO;
-import com.hyrule.eventos.hyrule.modelo.Participante;
-import com.hyrule.eventos.hyrule.servicio.PagoService;
-import com.hyrule.eventos.hyrule.dao.InscripcionDAO;
-import com.hyrule.eventos.hyrule.modelo.Inscripcion;
-import com.hyrule.eventos.hyrule.servicio.InscripcionService;
+import com.hyrule.eventos.hyrule.modelo.Actividad;
+import com.hyrule.eventos.hyrule.servicio.ActividadService;
+import com.hyrule.eventos.hyrule.servicio.AsistenciaService;
+
+import java.time.LocalTime;
 
 /**
  *
@@ -23,27 +22,33 @@ public class EventosHyrule {
         DBConnection connection = new DBConnection();
         connection.connect();
 
-        // Creamos participante nuevo
-        ParticipanteDAO pdao = new ParticipanteDAO();
-        Participante nuevo = new Participante("malon@hyrule.org", "Malon Ranch", "estudiante", "Lon Lon Ranch");
-        System.out.println("Crear participante (malon): " + pdao.crear(nuevo));
+        // Funcionalidades para actividad
+        ActividadService aService = new ActividadService();
+        Actividad nueva = new Actividad(
+                "ACT-00000003",
+                "EVT-00000001",
+                "charla",
+                "Charla de arqueria",
+                "link@hyrule.org", // instructor valido en EVT-00000001
+                LocalTime.of(14, 0),
+                LocalTime.of(16, 0),
+                2
+        );
+        System.out.println("Crear actividad validada: " + aService.crearConValidacion(nueva));
 
-        // Creamos inscripcion pendiente al evento pago EVT-00000001
-        InscripcionDAO idao = new InscripcionDAO();
-        Inscripcion ins = new Inscripcion("malon@hyrule.org", "EVT-00000001", "asistente", "pendiente");
-        System.out.println("Crear inscripcion (malon): " + idao.crear(ins));
+        // Funcionalidades para asistencia
+        AsistenciaService asistService = new AsistenciaService();
 
-        // Intentamos validar inscripcion sin pagar (debe fallar por pago insuficiente)
-        InscripcionService iservice = new InscripcionService();
-        System.out.println("Validar sin pagar (malon): " + iservice.validarInscripcion("malon@hyrule.org", "EVT-00000001"));
+        // Registramos asistencia de Malon (la inscripcion debe ser validada ya que hay cupo)
+        System.out.println("Asistencia Malon: " + asistService.registrarAsistencia("malon@hyrule.org", "ACT-00000003"));
 
-        // Registramos el pago completo y revalidamos automaticamente la inscripcion
-        PagoService pagoService = new PagoService();
-        System.out.println("Registrar pago + revalidar (malon): "
-                + pagoService.registrarPagoYRevalidar("malon@hyrule.org", "EVT-00000001", "efectivo", 75.00));
+        // Registramos asistencia de Zelda (la inscripcion debe ser validada ya que hay cupo)
+        System.out.println("Asistencia Zelda: " + asistService.registrarAsistencia("zelda@hyrule.edu", "ACT-00000003"));
 
-        // Verificamos el estado final de la inscripcion
-        Inscripcion ver = idao.obtener("malon@hyrule.org", "EVT-00000001");
-        System.out.println("Estado final (malon): " + (ver != null ? ver.getEstado() : "no existe"));
+        // Intentamos registrar asistencia duplicada de Malon (debe fallar ya que Malon fue inscrito anteriormente)
+        System.out.println("Asistencia Malon (duplicada): " + asistService.registrarAsistencia("malon@hyrule.org", "ACT-00000003"));
+
+        // Intentamos registrar a un tercero para saturar cupo (deberia fallar en cupo lleno si ya hay 2)
+        System.out.println("Asistencia Link (como asistente): " + asistService.registrarAsistencia("link@hyrule.org", "ACT-00000003"));
     }
 }

--- a/src/main/java/com/hyrule/eventos/hyrule/servicio/ActividadService.java
+++ b/src/main/java/com/hyrule/eventos/hyrule/servicio/ActividadService.java
@@ -1,0 +1,46 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package com.hyrule.eventos.hyrule.servicio;
+
+import com.hyrule.eventos.hyrule.dao.ActividadDAO;
+import com.hyrule.eventos.hyrule.dbconnection.DBConnection;
+import com.hyrule.eventos.hyrule.modelo.Actividad;
+
+import java.sql.*;
+
+/**
+ *
+ * @author Ludvi
+ */
+public class ActividadService {
+
+    private final ActividadDAO actividadDAO = new ActividadDAO();
+
+    public boolean crearConValidacion(Actividad a) {
+        // Verificamos que instructor este inscrito al evento y no como 'asistente'
+        final String sql = "SELECT tipo FROM inscripcion WHERE correo=? AND codigo_evento=? LIMIT 1";
+        try (Connection cn = DriverManager.getConnection(DBConnection.URL, DBConnection.USER_NAME, DBConnection.PASSWORD); PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setString(1, a.getCorreoInstructor());
+            ps.setString(2, a.getCodigoEvento());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    System.err.println("Instructor no esta inscrito al evento.");
+                    return false;
+                }
+                String tipoIns = rs.getString("tipo");
+                if ("asistente".equalsIgnoreCase(tipoIns)) {
+                    System.err.println("Instructor no puede ser 'asistente'.");
+                    return false;
+                }
+            }
+        } catch (SQLException ex) {
+            System.err.println("Error validando instructor: " + ex.getMessage());
+            return false;
+        }
+
+        // Creamos actividad
+        return actividadDAO.crear(a);
+    }
+}

--- a/src/main/java/com/hyrule/eventos/hyrule/servicio/AsistenciaService.java
+++ b/src/main/java/com/hyrule/eventos/hyrule/servicio/AsistenciaService.java
@@ -1,0 +1,67 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package com.hyrule.eventos.hyrule.servicio;
+
+import com.hyrule.eventos.hyrule.dao.ActividadDAO;
+import com.hyrule.eventos.hyrule.dao.AsistenciaDAO;
+import com.hyrule.eventos.hyrule.dbconnection.DBConnection;
+
+import java.sql.*;
+
+/**
+ *
+ * @author Ludvi
+ */
+public class AsistenciaService {
+
+    private final ActividadDAO actividadDAO = new ActividadDAO();
+    private final AsistenciaDAO asistenciaDAO = new AsistenciaDAO();
+
+    public boolean registrarAsistencia(String correo, String codigoActividad) {
+        // Tratamos de evitar asistencia duplicada
+        if (asistenciaDAO.existe(correo, codigoActividad)) {
+            System.err.println("Asistencia duplicada.");
+            return false;
+        }
+
+        // Obtenemos el evento de la actividad
+        String evento = actividadDAO.obtenerEventoDeActividad(codigoActividad);
+        if (evento == null) {
+            System.err.println("Actividad no existe.");
+            return false;
+        }
+
+        // Verificamos si la inscripcion es VALIDADA al evento
+        final String sqlVal = "SELECT estado FROM inscripcion WHERE correo=? AND codigo_evento=? LIMIT 1";
+        try (Connection cn = DriverManager.getConnection(DBConnection.URL, DBConnection.USER_NAME, DBConnection.PASSWORD); PreparedStatement ps = cn.prepareStatement(sqlVal)) {
+            ps.setString(1, correo);
+            ps.setString(2, evento);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    System.err.println("Participante no inscrito al evento de la actividad.");
+                    return false;
+                }
+                if (!"validada".equalsIgnoreCase(rs.getString("estado"))) {
+                    System.err.println("Inscripcion no esta validada.");
+                    return false;
+                }
+            }
+        } catch (SQLException ex) {
+            System.err.println("Error validando inscripcion: " + ex.getMessage());
+            return false;
+        }
+
+        // Verificamo el cupo de la actividad
+        int cupo = actividadDAO.obtenerCupo(codigoActividad);
+        int ocupados = actividadDAO.contarAsistencias(codigoActividad);
+        if (ocupados >= cupo) {
+            System.err.println("Cupo de la actividad lleno.");
+            return false;
+        }
+
+        // Insertamos la asistencia
+        return asistenciaDAO.crear(new com.hyrule.eventos.hyrule.modelo.Asistencia(correo, codigoActividad));
+    }
+}


### PR DESCRIPTION
Para mantener el DAO simple, ponemos la lógica de negocio en un service y verificamos que el CRUD en Actividad y Asistencia se realice satisfactoriamente, que valide las actividades para poder realizar las asistencias correctamente, con esto confirmamos que Evento/Participante/Inscripción/Pagos/Actividad/Asistencia están funcionando según lo veníamos planeando